### PR TITLE
Type indentation

### DIFF
--- a/test/test.sml
+++ b/test/test.sml
@@ -50,10 +50,10 @@ end
 structure MkList :> sig
   val group : { bininfo: BinInfo.info -> 'element,
                 smlinfo: SmlInfo.info -> 'element,
-                Cons: 'element * 'elements -> 'elements,
-                Nil: 'elements
-              } ->
-    GroupGraph.group -> 'elements
+                Cons: 'element * 'elements
+                  -> 'elements,
+                Nil: 'elements }
+    -> GroupGraph.group -> 'elements
 end = struct
 
   structure DG = DependencyGraph


### PR DESCRIPTION
sig type indent
no-indent in error nodes to lessen whiplash
indent for record types